### PR TITLE
Signed policy verification

### DIFF
--- a/implementation.go
+++ b/implementation.go
@@ -13,17 +13,18 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	v1 "github.com/carabiner-dev/policy/api/v1"
+	"github.com/carabiner-dev/policy/options"
 )
 
 type parserImplementation interface {
-	ParsePolicySet([]byte) (*v1.PolicySet, attestation.Verification, error)
-	ParsePolicy([]byte) (*v1.Policy, attestation.Verification, error)
+	ParsePolicySet(*options.ParseOptions, []byte) (*v1.PolicySet, attestation.Verification, error)
+	ParsePolicy(*options.ParseOptions, []byte) (*v1.Policy, attestation.Verification, error)
 }
 
 type defaultParserImplementationV1 struct{}
 
 // ParsePolicySet parses a policy set from a byte slice.
-func (dpi *defaultParserImplementationV1) ParsePolicySet(policySetData []byte) (*v1.PolicySet, attestation.Verification, error) {
+func (dpi *defaultParserImplementationV1) ParsePolicySet(opts *options.ParseOptions, policySetData []byte) (*v1.PolicySet, attestation.Verification, error) {
 	var verification attestation.Verification
 	var err error
 
@@ -67,7 +68,7 @@ func (dpi *defaultParserImplementationV1) ParsePolicySet(policySetData []byte) (
 }
 
 // ParsePolicy parses a policy from a byte slice.
-func (dpi *defaultParserImplementationV1) ParsePolicy(policyData []byte) (*v1.Policy, attestation.Verification, error) {
+func (dpi *defaultParserImplementationV1) ParsePolicy(opts *options.ParseOptions, policyData []byte) (*v1.Policy, attestation.Verification, error) {
 	var verification attestation.Verification
 	var err error
 

--- a/implementation.go
+++ b/implementation.go
@@ -115,8 +115,10 @@ func parseEnvelope(opts *options.ParseOptions, bundleData []byte) ([]byte, attes
 	}
 
 	// Verify the envelope, passing any keys defined in the options
-	if err := envelopes[0].Verify(opts.PublicKeys); err != nil {
-		return nil, nil, fmt.Errorf("verifying policy envelope: %w", err)
+	if opts.VerifySignatures {
+		if err := envelopes[0].Verify(opts.PublicKeys); err != nil {
+			return nil, nil, fmt.Errorf("verifying policy envelope: %w", err)
+		}
 	}
 
 	return envelopes[0].GetPredicate().GetData(), envelopes[0].GetPredicate().GetVerification(), nil

--- a/options/compile.go
+++ b/options/compile.go
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package options
+
+type CompileOptions struct {
+	ParseOptions
+}
+
+var DefaultCompileOptions = CompileOptions{
+	ParseOptions: DefaultParseOptions,
+}

--- a/options/options.go
+++ b/options/options.go
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package options
+
+import "errors"
+
+var ErrUnsupportedOptionsType = errors.New("unsupported options type")
+
+type OptFn func(Options) error
+
+type Options any

--- a/options/parse.go
+++ b/options/parse.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package options
+
+type ParseOptions struct {
+	VerificationOptions
+}
+
+var DefaultParseOptions = ParseOptions{
+	VerificationOptions: DefaultVerificationOptions,
+}
+
+type ParseOptFn func(*ParseOptions) error

--- a/options/parse.go
+++ b/options/parse.go
@@ -3,12 +3,48 @@
 
 package options
 
+import "errors"
+
+// ParseOptions control how the parses processes data
 type ParseOptions struct {
 	VerificationOptions
+	VerifySignatures bool
 }
 
 var DefaultParseOptions = ParseOptions{
 	VerificationOptions: DefaultVerificationOptions,
+	VerifySignatures:    true,
 }
 
-type ParseOptFn func(*ParseOptions) error
+// WithParseOptions replaces all parse options with a new set
+func WithParseOptions(newopts *ParseOptions) OptFn {
+	return func(opts Options) error {
+		switch o := opts.(type) {
+		case *ParseOptions:
+			o.IdentityStrings = newopts.IdentityStrings
+			o.PublicKeys = newopts.PublicKeys
+			o.VerificationOptions = newopts.VerificationOptions
+			o.VerifySignatures = newopts.VerifySignatures
+		case *CompileOptions:
+			o.ParseOptions = *newopts
+		default:
+			return ErrUnsupportedOptionsType
+		}
+		return nil
+	}
+}
+
+// WithVerifySignatures controls is policy signatures are verified when parsed
+func WithVerifySignatures(doVerify bool) OptFn {
+	return func(opts Options) error {
+		switch o := opts.(type) {
+		case *ParseOptions:
+			o.VerifySignatures = doVerify
+		case *CompileOptions:
+			o.VerifySignatures = doVerify
+		default:
+			return errors.New("unsupported options type")
+		}
+		return nil
+	}
+}

--- a/options/verification.go
+++ b/options/verification.go
@@ -29,3 +29,19 @@ func WithPublicKey(keys ...key.PublicKeyProvider) OptFn {
 		return nil
 	}
 }
+
+func WithIdentityString(istrings ...string) OptFn {
+	return func(opts Options) error {
+		switch o := opts.(type) {
+		case *ParseOptions:
+			o.IdentityStrings = append(o.IdentityStrings, istrings...)
+		case *CompileOptions:
+			o.IdentityStrings = append(o.IdentityStrings, istrings...)
+		case *VerificationOptions:
+			o.IdentityStrings = append(o.IdentityStrings, istrings...)
+		default:
+			return ErrUnsupportedOptionsType
+		}
+		return nil
+	}
+}

--- a/options/verification.go
+++ b/options/verification.go
@@ -14,4 +14,18 @@ type VerificationOptions struct {
 
 var DefaultVerificationOptions = VerificationOptions{}
 
-type VerificationOptFn func(*VerificationOptions)
+func WithPublicKey(keys ...key.PublicKeyProvider) OptFn {
+	return func(opts Options) error {
+		switch o := opts.(type) {
+		case *ParseOptions:
+			o.PublicKeys = append(o.PublicKeys, keys...)
+		case *CompileOptions:
+			o.PublicKeys = append(o.PublicKeys, keys...)
+		case *VerificationOptions:
+			o.PublicKeys = append(o.PublicKeys, keys...)
+		default:
+			return ErrUnsupportedOptionsType
+		}
+		return nil
+	}
+}

--- a/options/verification.go
+++ b/options/verification.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package options
+
+import (
+	"github.com/carabiner-dev/signer/key"
+)
+
+type VerificationOptions struct {
+	PublicKeys      []key.PublicKeyProvider
+	IdentityStrings []string
+}
+
+var DefaultVerificationOptions = VerificationOptions{}
+
+type VerificationOptFn func(*VerificationOptions)

--- a/parser.go
+++ b/parser.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/carabiner-dev/attestation"
 	"github.com/carabiner-dev/vcslocator"
 	"sigs.k8s.io/release-utils/http"
 
@@ -45,14 +46,14 @@ type Parser struct {
 // Open opens a Policy or policySet. This function supports remote locations
 // (https URLs or VCS locators) and will eventually verify signatures after
 // reading and parsing data (still under construction).
-func (p *Parser) Open(location string, funcs ...options.OptFn) (set *api.PolicySet, pcy *api.Policy, err error) {
+func (p *Parser) OpenVerify(location string, funcs ...options.OptFn) (set *api.PolicySet, pcy *api.Policy, v attestation.Verification, err error) {
 	// Open de PolicySet/Policy data from files or remote locations
 	var data []byte
 	switch {
 	case strings.HasPrefix(location, "git+https://"), strings.HasPrefix(location, "git+ssh://"):
 		var b bytes.Buffer
 		if err := vcslocator.CopyFile(location, &b); err != nil {
-			return nil, nil, fmt.Errorf("copying data from repository: %w", err)
+			return nil, nil, nil, fmt.Errorf("copying data from repository: %w", err)
 		}
 		data = b.Bytes()
 	case strings.HasPrefix(location, "https://"):
@@ -62,16 +63,24 @@ func (p *Parser) Open(location string, funcs ...options.OptFn) (set *api.PolicyS
 	}
 
 	if err != nil {
-		return nil, nil, fmt.Errorf("opening policy data: %w", err)
+		return nil, nil, nil, fmt.Errorf("opening policy data: %w", err)
 	}
 
 	// Parse the read data
-	set, pcy, err = p.ParsePolicyOrSet(data, funcs...)
+	set, pcy, v, err = p.ParseVerifyPolicyOrSet(data, funcs...)
 	if err != nil {
-		return nil, nil, fmt.Errorf("parsing policy data: %w", err)
+		return nil, nil, nil, fmt.Errorf("parsing policy data: %w", err)
 	}
 
-	return set, pcy, nil
+	return set, pcy, v, nil
+}
+
+// Open opens a Policy or policySet. This function supports remote locations
+// (https URLs or VCS locators) and will eventually verify signatures after
+// reading and parsing data (still under construction).
+func (p *Parser) Open(location string, funcs ...options.OptFn) (*api.PolicySet, *api.Policy, error) {
+	set, pcy, _, err := p.OpenVerify(location, funcs...)
+	return set, pcy, err
 }
 
 // ParseFile parses a policySet from a file
@@ -95,43 +104,55 @@ func (p *Parser) ParsePolicyFile(path string, funcs ...options.OptFn) (*api.Poli
 }
 
 // ParseSet parses a policy set.
-func (p *Parser) ParsePolicySet(policySetData []byte, funcs ...options.OptFn) (*api.PolicySet, error) {
-	opts := options.DefaultParseOptions
-	for _, f := range funcs {
-		if err := f(&opts); err != nil {
-			return nil, err
-		}
-	}
-	// Parse the policy set data
-	set, _, err := p.impl.ParsePolicySet(&opts, policySetData)
-	if err != nil {
-		return nil, fmt.Errorf("parsing policy source: %w", err)
-	}
-	return set, nil
-}
-
-// ParsePolicy parses a policy from its JSON representation or an envelope
-func (p *Parser) ParsePolicy(data []byte, funcs ...options.OptFn) (*api.Policy, error) {
-	opts := options.DefaultParseOptions
-	for _, f := range funcs {
-		if err := f(&opts); err != nil {
-			return nil, err
-		}
-	}
-	pcy, _, err := p.impl.ParsePolicy(&opts, data)
-	if err != nil {
-		return nil, fmt.Errorf("parsing policy data: %w", err)
-	}
-	return pcy, nil
-}
-
-// ParsePolicyOrSet takes json data and tries to parse a policy or a policy set
-// out of it. Returns an error if the JSON data is none.
-func (p *Parser) ParsePolicyOrSet(data []byte, funcs ...options.OptFn) (set *api.PolicySet, pcy *api.Policy, err error) {
+func (p *Parser) ParseVerifyPolicySet(policySetData []byte, funcs ...options.OptFn) (*api.PolicySet, attestation.Verification, error) {
 	opts := options.DefaultParseOptions
 	for _, f := range funcs {
 		if err := f(&opts); err != nil {
 			return nil, nil, err
+		}
+	}
+	// Parse the policy set data
+	set, v, err := p.impl.ParsePolicySet(&opts, policySetData)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing policy source: %w", err)
+	}
+	return set, v, nil
+}
+
+// ParseSet parses a policy set.
+func (p *Parser) ParsePolicySet(policySetData []byte, funcs ...options.OptFn) (*api.PolicySet, error) {
+	set, _, err := p.ParseVerifyPolicySet(policySetData, funcs...)
+	return set, err
+}
+
+// ParsePolicy parses a policy from its JSON representation or an envelope
+func (p *Parser) ParseVerifyPolicy(data []byte, funcs ...options.OptFn) (*api.Policy, attestation.Verification, error) {
+	opts := options.DefaultParseOptions
+	for _, f := range funcs {
+		if err := f(&opts); err != nil {
+			return nil, nil, err
+		}
+	}
+	pcy, v, err := p.impl.ParsePolicy(&opts, data)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing policy data: %w", err)
+	}
+	return pcy, v, nil
+}
+
+// ParsePolicy parses a policy from its JSON representation or an envelope
+func (p *Parser) ParsePolicy(data []byte, funcs ...options.OptFn) (*api.Policy, error) {
+	pcy, _, err := p.ParseVerifyPolicy(data, funcs...)
+	return pcy, err
+}
+
+// ParseVerifyPolicyOrSet parses a policy and verifies the signatures. It returns
+// a PolicySet or Policy and the signature verification results object.
+func (p *Parser) ParseVerifyPolicyOrSet(data []byte, funcs ...options.OptFn) (set *api.PolicySet, pcy *api.Policy, v attestation.Verification, err error) {
+	opts := options.DefaultParseOptions
+	for _, f := range funcs {
+		if err := f(&opts); err != nil {
+			return nil, nil, nil, err
 		}
 	}
 	var wg sync.WaitGroup
@@ -140,18 +161,25 @@ func (p *Parser) ParsePolicyOrSet(data []byte, funcs ...options.OptFn) (set *api
 	var errSet, errPolicy error
 	go func() {
 		defer wg.Done()
-		set, _, errSet = p.impl.ParsePolicySet(&opts, data)
+		set, v, errSet = p.impl.ParsePolicySet(&opts, data)
 	}()
 	go func() {
 		defer wg.Done()
-		pcy, _, errPolicy = p.impl.ParsePolicy(&opts, data)
+		pcy, v, errPolicy = p.impl.ParsePolicy(&opts, data)
 	}()
 
 	// Wait for both parsers
 	wg.Wait()
 
 	if (set == nil && pcy == nil) || (errSet != nil && errPolicy != nil) {
-		return nil, nil, errors.New("unable to parse a policy or policySet from data")
+		return nil, nil, v, errors.New("unable to parse a policy or policySet from data")
 	}
-	return set, pcy, nil
+	return set, pcy, v, nil
+}
+
+// ParsePolicyOrSet takes json data and tries to parse a policy or a policy set
+// out of it. Returns an error if the JSON data is none.
+func (p *Parser) ParsePolicyOrSet(data []byte, funcs ...options.OptFn) (*api.PolicySet, *api.Policy, error) {
+	set, pcy, _, err := p.ParseVerifyPolicyOrSet(data, funcs...)
+	return set, pcy, err
 }

--- a/parser.go
+++ b/parser.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/release-utils/http"
 
 	api "github.com/carabiner-dev/policy/api/v1"
+	"github.com/carabiner-dev/policy/options"
 )
 
 const (
@@ -44,7 +45,7 @@ type Parser struct {
 // Open opens a Policy or policySet. This function supports remote locations
 // (https URLs or VCS locators) and will eventually verify signatures after
 // reading and parsing data (still under construction).
-func (p *Parser) Open(location string) (set *api.PolicySet, pcy *api.Policy, err error) {
+func (p *Parser) Open(location string, funcs ...options.ParseOptFn) (set *api.PolicySet, pcy *api.Policy, err error) {
 	// Open de PolicySet/Policy data from files or remote locations
 	var data []byte
 	switch {
@@ -65,7 +66,7 @@ func (p *Parser) Open(location string) (set *api.PolicySet, pcy *api.Policy, err
 	}
 
 	// Parse the read data
-	set, pcy, err = p.ParsePolicyOrSet(data)
+	set, pcy, err = p.ParsePolicyOrSet(data, funcs...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("parsing policy data: %w", err)
 	}
@@ -74,39 +75,50 @@ func (p *Parser) Open(location string) (set *api.PolicySet, pcy *api.Policy, err
 }
 
 // ParseFile parses a policySet from a file
-func (p *Parser) ParsePolicySetFile(path string) (*api.PolicySet, error) {
-	// TODO(puerco): Support policies enclosed in envelopes
+func (p *Parser) ParsePolicySetFile(path string, funcs ...options.ParseOptFn) (*api.PolicySet, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading polciy file: %w", err)
+		return nil, fmt.Errorf("reading policy file: %w", err)
 	}
 
-	return p.ParsePolicySet(data)
+	return p.ParsePolicySet(data, funcs...)
 }
 
 // ParsePolicyFile parses a policy from a file
-func (p *Parser) ParsePolicyFile(path string) (*api.Policy, error) {
+func (p *Parser) ParsePolicyFile(path string, funcs ...options.ParseOptFn) (*api.Policy, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading polciy file: %w", err)
 	}
 
-	return p.ParsePolicy(data)
+	return p.ParsePolicy(data, funcs...)
 }
 
 // ParseSet parses a policy set.
-func (p *Parser) ParsePolicySet(policySetData []byte) (*api.PolicySet, error) {
+func (p *Parser) ParsePolicySet(policySetData []byte, funcs ...options.ParseOptFn) (*api.PolicySet, error) {
+	opts := options.DefaultParseOptions
+	for _, f := range funcs {
+		if err := f(&opts); err != nil {
+			return nil, err
+		}
+	}
 	// Parse the policy set data
-	set, _, err := p.impl.ParsePolicySet(policySetData)
+	set, _, err := p.impl.ParsePolicySet(&opts, policySetData)
 	if err != nil {
 		return nil, fmt.Errorf("parsing policy source: %w", err)
 	}
 	return set, nil
 }
 
-// ParsePolicy parses a policy file
-func (p *Parser) ParsePolicy(data []byte) (*api.Policy, error) {
-	pcy, _, err := p.impl.ParsePolicy(data)
+// ParsePolicy parses a policy from its JSON representation or an envelope
+func (p *Parser) ParsePolicy(data []byte, funcs ...options.ParseOptFn) (*api.Policy, error) {
+	opts := options.DefaultParseOptions
+	for _, f := range funcs {
+		if err := f(&opts); err != nil {
+			return nil, err
+		}
+	}
+	pcy, _, err := p.impl.ParsePolicy(&opts, data)
 	if err != nil {
 		return nil, fmt.Errorf("parsing policy data: %w", err)
 	}
@@ -115,18 +127,24 @@ func (p *Parser) ParsePolicy(data []byte) (*api.Policy, error) {
 
 // ParsePolicyOrSet takes json data and tries to parse a policy or a policy set
 // out of it. Returns an error if the JSON data is none.
-func (p *Parser) ParsePolicyOrSet(data []byte) (set *api.PolicySet, pcy *api.Policy, err error) {
+func (p *Parser) ParsePolicyOrSet(data []byte, funcs ...options.ParseOptFn) (set *api.PolicySet, pcy *api.Policy, err error) {
+	opts := options.DefaultParseOptions
+	for _, f := range funcs {
+		if err := f(&opts); err != nil {
+			return nil, nil, err
+		}
+	}
 	var wg sync.WaitGroup
 	wg.Add(2)
 
 	var errSet, errPolicy error
 	go func() {
 		defer wg.Done()
-		set, _, errSet = p.impl.ParsePolicySet(data)
+		set, _, errSet = p.impl.ParsePolicySet(&opts, data)
 	}()
 	go func() {
 		defer wg.Done()
-		pcy, _, errPolicy = p.impl.ParsePolicy(data)
+		pcy, _, errPolicy = p.impl.ParsePolicy(&opts, data)
 	}()
 
 	// Wait for both parsers

--- a/parser.go
+++ b/parser.go
@@ -45,7 +45,7 @@ type Parser struct {
 // Open opens a Policy or policySet. This function supports remote locations
 // (https URLs or VCS locators) and will eventually verify signatures after
 // reading and parsing data (still under construction).
-func (p *Parser) Open(location string, funcs ...options.ParseOptFn) (set *api.PolicySet, pcy *api.Policy, err error) {
+func (p *Parser) Open(location string, funcs ...options.OptFn) (set *api.PolicySet, pcy *api.Policy, err error) {
 	// Open de PolicySet/Policy data from files or remote locations
 	var data []byte
 	switch {
@@ -75,7 +75,7 @@ func (p *Parser) Open(location string, funcs ...options.ParseOptFn) (set *api.Po
 }
 
 // ParseFile parses a policySet from a file
-func (p *Parser) ParsePolicySetFile(path string, funcs ...options.ParseOptFn) (*api.PolicySet, error) {
+func (p *Parser) ParsePolicySetFile(path string, funcs ...options.OptFn) (*api.PolicySet, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading policy file: %w", err)
@@ -85,7 +85,7 @@ func (p *Parser) ParsePolicySetFile(path string, funcs ...options.ParseOptFn) (*
 }
 
 // ParsePolicyFile parses a policy from a file
-func (p *Parser) ParsePolicyFile(path string, funcs ...options.ParseOptFn) (*api.Policy, error) {
+func (p *Parser) ParsePolicyFile(path string, funcs ...options.OptFn) (*api.Policy, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading polciy file: %w", err)
@@ -95,7 +95,7 @@ func (p *Parser) ParsePolicyFile(path string, funcs ...options.ParseOptFn) (*api
 }
 
 // ParseSet parses a policy set.
-func (p *Parser) ParsePolicySet(policySetData []byte, funcs ...options.ParseOptFn) (*api.PolicySet, error) {
+func (p *Parser) ParsePolicySet(policySetData []byte, funcs ...options.OptFn) (*api.PolicySet, error) {
 	opts := options.DefaultParseOptions
 	for _, f := range funcs {
 		if err := f(&opts); err != nil {
@@ -111,7 +111,7 @@ func (p *Parser) ParsePolicySet(policySetData []byte, funcs ...options.ParseOptF
 }
 
 // ParsePolicy parses a policy from its JSON representation or an envelope
-func (p *Parser) ParsePolicy(data []byte, funcs ...options.ParseOptFn) (*api.Policy, error) {
+func (p *Parser) ParsePolicy(data []byte, funcs ...options.OptFn) (*api.Policy, error) {
 	opts := options.DefaultParseOptions
 	for _, f := range funcs {
 		if err := f(&opts); err != nil {
@@ -127,7 +127,7 @@ func (p *Parser) ParsePolicy(data []byte, funcs ...options.ParseOptFn) (*api.Pol
 
 // ParsePolicyOrSet takes json data and tries to parse a policy or a policy set
 // out of it. Returns an error if the JSON data is none.
-func (p *Parser) ParsePolicyOrSet(data []byte, funcs ...options.ParseOptFn) (set *api.PolicySet, pcy *api.Policy, err error) {
+func (p *Parser) ParsePolicyOrSet(data []byte, funcs ...options.OptFn) (set *api.PolicySet, pcy *api.Policy, err error) {
 	opts := options.DefaultParseOptions
 	for _, f := range funcs {
 		if err := f(&opts); err != nil {


### PR DESCRIPTION
This PR adds the verification methods to the policy parser. While we were able to verify the signatures, there was no way to surface the policy signatures verfication data or the checked identities.

Now, all the `Parse*` functions offer new `ParseVerify*` variants that return the signature verifications. All methods also support fuctional options which for now allow to pass identities that can be enforced when verifying.