### PR TITLE
Fix bug in policy assembly

### DIFF
--- a/compiler_implementation.go
+++ b/compiler_implementation.go
@@ -305,7 +305,57 @@ func (dci *defaultCompilerImpl) assemblePolicy(opts *CompilerOptions, recurse in
 	tenets = append(tenets, appenders...)
 
 	// Merge the policy overlay onto the remote policy
-	proto.Merge(assembledPolicy, p)
+	// Only merge non-empty Meta fields to avoid overwriting with defaults
+	if p.Meta != nil {
+		if assembledPolicy.Meta == nil {
+			assembledPolicy.Meta = &api.Meta{}
+		}
+		if p.Meta.Runtime != "" {
+			assembledPolicy.Meta.Runtime = p.Meta.Runtime
+		}
+		if p.Meta.Description != "" {
+			assembledPolicy.Meta.Description = p.Meta.Description
+		}
+		if p.Meta.AssertMode != "" {
+			assembledPolicy.Meta.AssertMode = p.Meta.AssertMode
+		}
+		if p.Meta.Version != 0 {
+			assembledPolicy.Meta.Version = p.Meta.Version
+		}
+		if p.Meta.Enforce != "" {
+			assembledPolicy.Meta.Enforce = p.Meta.Enforce
+		}
+		if p.Meta.Expiration != nil {
+			assembledPolicy.Meta.Expiration = p.Meta.Expiration
+		}
+		if len(p.Meta.Controls) > 0 {
+			assembledPolicy.Meta.Controls = p.Meta.Controls
+		}
+	}
+	// Merge other fields (excluding Meta and Tenets which are handled separately)
+	if p.Id != "" {
+		assembledPolicy.Id = p.Id
+	}
+	if len(p.Context) > 0 {
+		if assembledPolicy.Context == nil {
+			assembledPolicy.Context = make(map[string]*api.ContextVal)
+		}
+		for k, v := range p.Context {
+			assembledPolicy.Context[k] = v
+		}
+	}
+	if len(p.Chain) > 0 {
+		assembledPolicy.Chain = p.Chain
+	}
+	if len(p.Identities) > 0 {
+		assembledPolicy.Identities = p.Identities
+	}
+	if p.Predicates != nil {
+		assembledPolicy.Predicates = p.Predicates
+	}
+	if len(p.Transformers) > 0 {
+		assembledPolicy.Transformers = p.Transformers
+	}
 	assembledPolicy.Tenets = tenets
 	assembledPolicy.Source = nil
 	return assembledPolicy, nil

--- a/implementation.go
+++ b/implementation.go
@@ -49,6 +49,12 @@ func (dpi *defaultParserImplementationV1) ParsePolicySet(opts *options.ParseOpti
 	}
 
 	for _, p := range set.Policies {
+		// Don't apply defaults to policies with remote sources
+		// They will get their defaults from the remote policy during assembly
+		if p.GetSource() != nil {
+			continue
+		}
+
 		if p.GetMeta() == nil {
 			p.Meta = &v1.Meta{}
 		}


### PR DESCRIPTION
This PR fixes a bug that was causing some values to be replaced incorrectly when the assembler merged code from remote policy refs. 


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>