### PR TITLE
Initial check in of the policy updater

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,10 @@ require (
 	github.com/carabiner-dev/hasher v0.2.3
 	github.com/carabiner-dev/signer v0.4.3
 	github.com/carabiner-dev/vcslocator v0.4.2
+	github.com/go-git/go-git/v5 v5.17.2
 	github.com/hjson/hjson-go/v4 v4.6.0
 	github.com/in-toto/attestation v1.2.0
+	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/protobuf v1.36.11
@@ -46,7 +48,6 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.8.1-0.20260407233109-416e0a5b21a8 // indirect
-	github.com/go-git/go-git/v5 v5.17.2 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -90,7 +91,6 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.21 // indirect
-	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 // indirect
 	github.com/olekukonko/errors v1.2.0 // indirect

--- a/updater.go
+++ b/updater.go
@@ -1,0 +1,543 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/carabiner-dev/hasher"
+	"github.com/carabiner-dev/vcslocator"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage/memory"
+	intoto "github.com/in-toto/attestation/go/v1"
+	"github.com/nozzle/throttler"
+	"google.golang.org/protobuf/proto"
+
+	api "github.com/carabiner-dev/policy/api/v1"
+	"github.com/carabiner-dev/policy/options"
+)
+
+// RefUpdate describes one external reference whose upstream content has
+// changed. Old is the reference as it appears in the policy source; New
+// is a ref pointing at the new commit with refreshed digests.
+type RefUpdate struct {
+	Old *api.PolicyRef
+	New *api.PolicyRef
+}
+
+// Updater checks policy source files for references that have updates
+// available in their upstream repositories.
+type Updater struct {
+	// MaxParallel caps concurrent remote operations. Defaults to 4.
+	MaxParallel int
+}
+
+// NewUpdater returns a new Updater with sane defaults.
+func NewUpdater() *Updater {
+	return &Updater{MaxParallel: 4}
+}
+
+// CheckUpdates resolves each location (a policy file, a directory, or a
+// VCS locator) into a set of policy source files, extracts their external
+// references and checks each referenced repository for updates. The
+// returned map is keyed by source file path and lists the references that
+// need to be updated.
+func (u *Updater) CheckUpdates(locations ...string) (map[string][]*RefUpdate, error) {
+	if len(locations) == 0 {
+		return nil, errors.New("no locations provided")
+	}
+
+	sources, cleanup, err := u.collectSources(locations)
+	defer cleanup()
+	if err != nil {
+		return nil, err
+	}
+	if len(sources) == 0 {
+		return nil, errors.New("no policy source files found")
+	}
+
+	refs := u.extractAllRefs(sources)
+	if len(refs) == 0 {
+		return map[string][]*RefUpdate{}, nil
+	}
+
+	parallel := u.MaxParallel
+	if parallel <= 0 {
+		parallel = 4
+	}
+
+	type repoKey struct {
+		url, refName string
+	}
+	heads := map[repoKey]string{}
+	var hmu sync.Mutex
+
+	byRepo := map[repoKey][]*extractedRef{}
+	for _, r := range refs {
+		if r.components == nil {
+			continue
+		}
+		k := repoKey{url: r.components.RepoURL(), refName: remoteRefName(r.components)}
+		byRepo[k] = append(byRepo[k], r)
+	}
+
+	// 1) Resolve latest commit per unique (repo, ref) in parallel.
+	t := throttler.New(parallel, len(byRepo))
+	var headErr error
+	var hErrMu sync.Mutex
+	for k := range byRepo {
+		go func(k repoKey) {
+			h, err := lsRemoteHead(k.url, k.refName)
+			if err != nil {
+				hErrMu.Lock()
+				if headErr == nil {
+					headErr = fmt.Errorf("ls-remote %s: %w", k.url, err)
+				}
+				hErrMu.Unlock()
+				t.Done(nil)
+				return
+			}
+			hmu.Lock()
+			heads[k] = h
+			hmu.Unlock()
+			t.Done(nil)
+		}(k)
+		t.Throttle()
+	}
+	if headErr != nil {
+		return nil, headErr
+	}
+
+	// 2) For each ref with a changed head, fetch the file at old and new
+	//    and compare digests.
+	results := map[string][]*RefUpdate{}
+	var rmu sync.Mutex
+
+	// Cache fetched file bytes by locator-at-commit string.
+	byteCache := map[string][]byte{}
+	var bmu sync.Mutex
+	fetchBytes := func(locator string) ([]byte, error) {
+		bmu.Lock()
+		if b, ok := byteCache[locator]; ok {
+			bmu.Unlock()
+			return b, nil
+		}
+		bmu.Unlock()
+		var buf bytes.Buffer
+		if err := vcslocator.CopyFile(locator, &buf); err != nil {
+			return nil, err
+		}
+		data := buf.Bytes()
+		bmu.Lock()
+		byteCache[locator] = data
+		bmu.Unlock()
+		return data, nil
+	}
+
+	t2 := throttler.New(parallel, len(refs))
+	for _, r := range refs {
+		go func(r *extractedRef) {
+			defer t2.Done(nil)
+			if r.components == nil {
+				return
+			}
+			k := repoKey{url: r.components.RepoURL(), refName: remoteRefName(r.components)}
+			hmu.Lock()
+			newCommit := heads[k]
+			hmu.Unlock()
+			oldCommit := r.components.Commit
+			if newCommit == "" || newCommit == oldCommit {
+				return
+			}
+
+			newLocator := buildLocatorAt(r.components, newCommit)
+			newBytes, err := fetchBytes(newLocator)
+			if err != nil {
+				return
+			}
+
+			oldDigests := map[string]string{}
+			if loc := r.original.GetLocation(); loc != nil {
+				for k, v := range loc.GetDigest() {
+					oldDigests[k] = v
+				}
+			}
+
+			// If the old ref had no recorded digest we need to fetch the
+			// old bytes to know whether content actually changed.
+			if _, haveSha256 := oldDigests["sha256"]; !haveSha256 && oldCommit != "" {
+				oldLocator := buildLocatorAt(r.components, oldCommit)
+				oldBytes, err := fetchBytes(oldLocator)
+				if err != nil {
+					return
+				}
+				oldHashed, err := hashBytes(oldBytes, []string{string(intoto.AlgorithmSHA256)})
+				if err != nil {
+					return
+				}
+				for k, v := range oldHashed {
+					oldDigests[k] = v
+				}
+			}
+
+			newDigests, err := computeDigests(newBytes, oldDigests)
+			if err != nil {
+				return
+			}
+			if newCommit != "" {
+				newDigests[string(intoto.AlgorithmGitCommit)] = newCommit
+			}
+
+			if digestsMatch(oldDigests, newDigests) {
+				return
+			}
+
+			newRef := cloneRef(r.original)
+			if newRef.Location == nil {
+				newRef.Location = &intoto.ResourceDescriptor{}
+			}
+			newRef.Location.Uri = newLocator
+			newRef.Location.DownloadLocation = ""
+			newRef.Location.Digest = newDigests
+
+			rmu.Lock()
+			results[r.file] = append(results[r.file], &RefUpdate{
+				Old: r.original,
+				New: newRef,
+			})
+			rmu.Unlock()
+		}(r)
+		t2.Throttle()
+	}
+
+	return results, nil
+}
+
+// extractedRef is the internal working copy of a reference under review.
+type extractedRef struct {
+	file       string
+	original   *api.PolicyRef
+	components *vcslocator.Components
+}
+
+// collectSources turns each input location into a slice of local policy
+// file paths. For VCS-locator inputs it clones the repository to a temp
+// directory and treats the result as a filesystem input.
+func (u *Updater) collectSources(locations []string) (files []string, cleanup func(), err error) {
+	var tmpDirs []string
+	cleanup = func() {
+		for _, d := range tmpDirs {
+			if rerr := os.RemoveAll(d); rerr != nil {
+				err = errors.Join(err, fmt.Errorf("removing temp dir %q: %w", d, rerr))
+			}
+		}
+	}
+
+	parser := NewParser()
+	for _, loc := range locations {
+		if info, err := os.Stat(loc); err == nil {
+			if info.IsDir() {
+				found, err := walkForPolicyFiles(loc, parser)
+				if err != nil {
+					return nil, cleanup, err
+				}
+				files = append(files, found...)
+			} else if isPolicyFile(loc, parser) {
+				files = append(files, loc)
+			}
+			continue
+		}
+
+		// Not on the filesystem; try as a VCS locator.
+		l := vcslocator.Locator(loc)
+		comps, err := l.Parse()
+		if err != nil || comps.Tool != "git" {
+			return nil, cleanup, fmt.Errorf("location %q is not a file, directory, or valid VCS locator", loc)
+		}
+
+		tmp, err := os.MkdirTemp("", "policyctl-checkupdate-")
+		if err != nil {
+			return nil, cleanup, fmt.Errorf("creating temp dir: %w", err)
+		}
+		tmpDirs = append(tmpDirs, tmp)
+
+		if _, err := vcslocator.CloneRepository(loc, vcslocator.WithClonePath(tmp)); err != nil {
+			return nil, cleanup, fmt.Errorf("cloning %q: %w", loc, err)
+		}
+
+		target := tmp
+		if comps.SubPath != "" {
+			target = filepath.Join(tmp, comps.SubPath)
+		}
+		info, err := os.Stat(target)
+		if err != nil {
+			return nil, cleanup, fmt.Errorf("resolving subpath %q: %w", comps.SubPath, err)
+		}
+		if info.IsDir() {
+			found, err := walkForPolicyFiles(target, parser)
+			if err != nil {
+				return nil, cleanup, err
+			}
+			files = append(files, found...)
+		} else if isPolicyFile(target, parser) {
+			files = append(files, target)
+		}
+	}
+
+	return files, cleanup, nil
+}
+
+func walkForPolicyFiles(root string, parser *Parser) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if strings.HasPrefix(d.Name(), ".") && p != root {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(p))
+		if ext != ".json" && ext != ".hjson" && ext != ".ampel" {
+			return nil
+		}
+		if isPolicyFile(p, parser) {
+			out = append(out, p)
+		}
+		return nil
+	})
+	return out, err
+}
+
+func isPolicyFile(path string, parser *Parser) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	set, pcy, grp, _, err := parser.ParseVerifyPolicyOrSetOrGroup(data, options.WithVerifySignatures(false))
+	if err != nil {
+		return false
+	}
+	return set != nil || pcy != nil || grp != nil
+}
+
+// extractAllRefs parses each source file and collects external references.
+func (u *Updater) extractAllRefs(files []string) []*extractedRef {
+	var refs []*extractedRef
+	parser := NewParser()
+	for _, path := range files {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		set, pcy, grp, _, err := parser.ParseVerifyPolicyOrSetOrGroup(data, options.WithVerifySignatures(false))
+		if err != nil {
+			continue
+		}
+
+		add := func(ref *api.PolicyRef) {
+			if ref == nil || ref.GetLocation() == nil {
+				return
+			}
+			uri := ref.GetSourceURL()
+			if uri == "" {
+				return
+			}
+			comps, cerr := vcslocator.Locator(uri).Parse()
+			if cerr != nil {
+				return
+			}
+			refs = append(refs, &extractedRef{
+				file:       path,
+				original:   ref,
+				components: comps,
+			})
+		}
+
+		switch {
+		case set != nil:
+			for _, r := range set.GetCommon().GetReferences() {
+				add(r)
+			}
+			for _, p := range set.GetPolicies() {
+				add(p.GetSource())
+			}
+			for _, g := range set.GetGroups() {
+				add(groupRefToPolicyRef(g.GetSource()))
+				for _, b := range g.GetBlocks() {
+					for _, p := range b.GetPolicies() {
+						add(p.GetSource())
+					}
+				}
+			}
+		case pcy != nil:
+			add(pcy.GetSource())
+		case grp != nil:
+			add(groupRefToPolicyRef(grp.GetSource()))
+			for _, b := range grp.GetBlocks() {
+				for _, p := range b.GetPolicies() {
+					add(p.GetSource())
+				}
+			}
+		}
+	}
+	return refs
+}
+
+// groupRefToPolicyRef projects a PolicyGroupRef into the shape of a
+// PolicyRef so both can flow through the same update pipeline.
+func groupRefToPolicyRef(g *api.PolicyGroupRef) *api.PolicyRef {
+	if g == nil {
+		return nil
+	}
+	return &api.PolicyRef{
+		Id:       g.GetId(),
+		Version:  g.GetVersion(),
+		Identity: g.GetIdentity(),
+		Location: g.GetLocation(),
+	}
+}
+
+func cloneRef(r *api.PolicyRef) *api.PolicyRef {
+	cp, ok := proto.Clone(r).(*api.PolicyRef)
+	if !ok {
+		return &api.PolicyRef{}
+	}
+	return cp
+}
+
+// hashBytes hashes `data` using the given algorithm names. Algorithms not
+// supported by the hasher package are skipped.
+func hashBytes(data []byte, algos []string) (map[string]string, error) {
+	filtered := []intoto.HashAlgorithm{}
+	for _, a := range algos {
+		algo := intoto.HashAlgorithm(a)
+		if _, ok := hasher.HasherFactory[algo]; ok {
+			filtered = append(filtered, algo)
+		}
+	}
+	if len(filtered) == 0 {
+		return map[string]string{}, nil
+	}
+	h := hasher.New()
+	h.Options.Algorithms = filtered
+	list, err := h.HashReaders([]io.Reader{bytes.NewReader(data)})
+	if err != nil {
+		return nil, fmt.Errorf("hashing: %w", err)
+	}
+	if list == nil || len(*list) == 0 {
+		return map[string]string{}, nil
+	}
+	out := map[string]string{}
+	for algo, digest := range (*list)[0] {
+		out[string(algo)] = digest
+	}
+	return out, nil
+}
+
+// computeDigests produces digests for `data` covering every algorithm
+// present in `reference` plus sha256 as a guaranteed default.
+func computeDigests(data []byte, reference map[string]string) (map[string]string, error) {
+	seen := map[string]struct{}{string(intoto.AlgorithmSHA256): {}}
+	algos := []string{string(intoto.AlgorithmSHA256)}
+	for k := range reference {
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		algos = append(algos, k)
+	}
+	return hashBytes(data, algos)
+}
+
+// digestsMatch reports whether newDigests is consistent with oldDigests.
+// Every algorithm in newDigests must either match the corresponding entry
+// in oldDigests or have no corresponding entry at all. At least one
+// algorithm must overlap between the two maps — if none do, the result
+// is false.
+func digestsMatch(oldDigests, newDigests map[string]string) bool {
+	overlap := 0
+	for algo, nv := range newDigests {
+		ov, ok := oldDigests[algo]
+		if !ok {
+			continue
+		}
+		if ov != nv {
+			return false
+		}
+		overlap++
+	}
+	return overlap > 0
+}
+
+// lsRemoteHead queries the remote for the latest commit of refName. If
+// refName is empty, HEAD is resolved.
+func lsRemoteHead(repoURL, refName string) (string, error) {
+	rem := git.NewRemote(memory.NewStorage(), &config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{repoURL},
+	})
+	refs, err := rem.List(&git.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	if refName == "" {
+		for _, r := range refs {
+			if r.Name() == plumbing.HEAD && r.Type() == plumbing.SymbolicReference {
+				refName = r.Target().String()
+				break
+			}
+		}
+	}
+
+	for _, r := range refs {
+		if r.Name().String() == refName {
+			return r.Hash().String(), nil
+		}
+	}
+	for _, r := range refs {
+		if r.Name() == plumbing.HEAD && r.Type() == plumbing.HashReference {
+			return r.Hash().String(), nil
+		}
+	}
+	return "", fmt.Errorf("ref %q not found in remote", refName)
+}
+
+// remoteRefName converts the parsed locator into a remote ref name. Empty
+// means "HEAD/default branch".
+func remoteRefName(c *vcslocator.Components) string {
+	switch {
+	case c.Branch != "":
+		return "refs/heads/" + c.Branch
+	case c.Tag != "":
+		return "refs/tags/" + c.Tag
+	default:
+		return ""
+	}
+}
+
+// buildLocatorAt rewrites a locator to point at a specific commit while
+// preserving the subpath.
+func buildLocatorAt(c *vcslocator.Components, commit string) string {
+	repo := strings.TrimPrefix(c.RepoPath, "/")
+	var b strings.Builder
+	fmt.Fprintf(&b, "git+%s://%s/%s@%s", c.Transport, c.Hostname, repo, commit)
+	if c.SubPath != "" {
+		fmt.Fprintf(&b, "#%s", c.SubPath)
+	}
+	return b.String()
+}

--- a/updater_test.go
+++ b/updater_test.go
@@ -1,0 +1,419 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/carabiner-dev/vcslocator"
+	intoto "github.com/in-toto/attestation/go/v1"
+	"github.com/stretchr/testify/require"
+
+	api "github.com/carabiner-dev/policy/api/v1"
+)
+
+func TestDigestsMatch(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		oldDigests map[string]string
+		newDigests map[string]string
+		want       bool
+	}{
+		{
+			name:       "single-algo-match",
+			oldDigests: map[string]string{"sha256": "aaa"},
+			newDigests: map[string]string{"sha256": "aaa"},
+			want:       true,
+		},
+		{
+			name:       "single-algo-mismatch",
+			oldDigests: map[string]string{"sha256": "aaa"},
+			newDigests: map[string]string{"sha256": "bbb"},
+			want:       false,
+		},
+		{
+			name:       "shared-matches-extras-in-new-ignored",
+			oldDigests: map[string]string{"sha256": "aaa"},
+			newDigests: map[string]string{"sha256": "aaa", "sha512": "zzz"},
+			want:       true,
+		},
+		{
+			name:       "any-shared-mismatch-fails",
+			oldDigests: map[string]string{"sha256": "aaa", "sha512": "yyy"},
+			newDigests: map[string]string{"sha256": "aaa", "sha512": "zzz"},
+			want:       false,
+		},
+		{
+			name:       "no-overlap-returns-false",
+			oldDigests: map[string]string{"sha1": "111"},
+			newDigests: map[string]string{"sha256": "aaa"},
+			want:       false,
+		},
+		{
+			name:       "both-empty-returns-false",
+			oldDigests: map[string]string{},
+			newDigests: map[string]string{},
+			want:       false,
+		},
+		{
+			name:       "old-has-extra-algos-still-match",
+			oldDigests: map[string]string{"sha256": "aaa", "sha512": "yyy"},
+			newDigests: map[string]string{"sha256": "aaa"},
+			want:       true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, digestsMatch(tc.oldDigests, tc.newDigests))
+		})
+	}
+}
+
+func TestHashBytes(t *testing.T) {
+	t.Parallel()
+	// sha256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+	const want = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+
+	t.Run("known-sha256", func(t *testing.T) {
+		t.Parallel()
+		got, err := hashBytes([]byte("hello"), []string{"sha256"})
+		require.NoError(t, err)
+		require.Equal(t, want, got["sha256"])
+	})
+
+	t.Run("unsupported-algo-skipped", func(t *testing.T) {
+		t.Parallel()
+		got, err := hashBytes([]byte("hello"), []string{"sha256", "made-up-algo"})
+		require.NoError(t, err)
+		require.Contains(t, got, "sha256")
+		require.NotContains(t, got, "made-up-algo")
+	})
+
+	t.Run("only-unsupported-returns-empty", func(t *testing.T) {
+		t.Parallel()
+		got, err := hashBytes([]byte("hello"), []string{"made-up-algo"})
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+}
+
+func TestComputeDigests(t *testing.T) {
+	t.Parallel()
+	t.Run("always-includes-sha256", func(t *testing.T) {
+		t.Parallel()
+		got, err := computeDigests([]byte("hello"), nil)
+		require.NoError(t, err)
+		require.Contains(t, got, "sha256")
+	})
+
+	t.Run("covers-reference-algorithms", func(t *testing.T) {
+		t.Parallel()
+		got, err := computeDigests([]byte("hello"), map[string]string{
+			"sha256": "old",
+			"sha512": "old",
+		})
+		require.NoError(t, err)
+		require.Contains(t, got, "sha256")
+		require.Contains(t, got, "sha512")
+	})
+
+	t.Run("unknown-reference-algo-skipped", func(t *testing.T) {
+		t.Parallel()
+		got, err := computeDigests([]byte("hello"), map[string]string{
+			"sha256":     "old",
+			"bogus-algo": "old",
+		})
+		require.NoError(t, err)
+		require.Contains(t, got, "sha256")
+		require.NotContains(t, got, "bogus-algo")
+	})
+}
+
+func TestBuildLocatorAt(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		repo   string
+		sub    string
+		commit string
+		want   string
+	}{
+		{
+			name:   "with-subpath",
+			repo:   "/carabiner-dev/policies",
+			sub:    "sbom/sbom-exists.json",
+			commit: "deadbeef",
+			want:   "git+https://github.com/carabiner-dev/policies@deadbeef#sbom/sbom-exists.json",
+		},
+		{
+			name:   "no-subpath",
+			repo:   "carabiner-dev/policies",
+			sub:    "",
+			commit: "deadbeef",
+			want:   "git+https://github.com/carabiner-dev/policies@deadbeef",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildLocatorAt(&vcsTestComponents(tc.repo, tc.sub).Components, tc.commit)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestRemoteRefName(t *testing.T) {
+	t.Parallel()
+	t.Run("branch-wins", func(t *testing.T) {
+		t.Parallel()
+		c := vcsTestComponents("x/y", "").Components
+		c.Branch = "main"
+		c.Tag = "v1"
+		require.Equal(t, "refs/heads/main", remoteRefName(&c))
+	})
+
+	t.Run("tag", func(t *testing.T) {
+		t.Parallel()
+		c := vcsTestComponents("x/y", "").Components
+		c.Tag = "v1.2.3"
+		require.Equal(t, "refs/tags/v1.2.3", remoteRefName(&c))
+	})
+
+	t.Run("neither-returns-empty", func(t *testing.T) {
+		t.Parallel()
+		c := vcsTestComponents("x/y", "").Components
+		require.Empty(t, remoteRefName(&c))
+	})
+}
+
+func TestGroupRefToPolicyRef(t *testing.T) {
+	t.Parallel()
+	t.Run("nil-returns-nil", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, groupRefToPolicyRef(nil))
+	})
+
+	t.Run("copies-id-version-and-location", func(t *testing.T) {
+		t.Parallel()
+		in := &api.PolicyGroupRef{
+			Id:      "group-1",
+			Version: 3,
+			Location: &intoto.ResourceDescriptor{
+				Uri:    "git+https://example.com/x/y@abc#g.json",
+				Digest: map[string]string{"sha256": "aaa"},
+			},
+		}
+		out := groupRefToPolicyRef(in)
+		require.NotNil(t, out)
+		require.Equal(t, "group-1", out.GetId())
+		require.EqualValues(t, 3, out.GetVersion())
+		require.Equal(t, in.GetLocation().GetUri(), out.GetLocation().GetUri())
+		require.Equal(t, "aaa", out.GetLocation().GetDigest()["sha256"])
+	})
+}
+
+func TestCloneRef(t *testing.T) {
+	t.Parallel()
+	orig := &api.PolicyRef{
+		Id: "ref-1",
+		Location: &intoto.ResourceDescriptor{
+			Uri:    "git+https://example.com/x/y@abc#p.json",
+			Digest: map[string]string{"sha256": "aaa"},
+		},
+	}
+	cp := cloneRef(orig)
+	require.NotSame(t, orig, cp)
+	require.Equal(t, orig.GetId(), cp.GetId())
+	require.Equal(t, orig.GetLocation().GetUri(), cp.GetLocation().GetUri())
+
+	// Mutating the clone does not alter the source.
+	cp.Location.Uri = "mutated"
+	cp.Location.Digest["sha256"] = "bbb"
+	require.Equal(t, "git+https://example.com/x/y@abc#p.json", orig.GetLocation().GetUri())
+	require.Equal(t, "aaa", orig.GetLocation().GetDigest()["sha256"])
+}
+
+func TestIsPolicyFile(t *testing.T) {
+	t.Parallel()
+	parser := NewParser()
+
+	t.Run("valid-policy-fixture", func(t *testing.T) {
+		t.Parallel()
+		require.True(t, isPolicyFile("testdata/policy.single.json", parser))
+	})
+
+	t.Run("valid-policyset-fixture", func(t *testing.T) {
+		t.Parallel()
+		require.True(t, isPolicyFile("testdata/policy.remoteref.json", parser))
+	})
+
+	t.Run("missing-file", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, isPolicyFile("testdata/does-not-exist.json", parser))
+	})
+
+	t.Run("non-policy-json", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		p := filepath.Join(dir, "junk.json")
+		require.NoError(t, os.WriteFile(p, []byte(`{"random":"object"}`), 0o600))
+		require.False(t, isPolicyFile(p, parser))
+	})
+}
+
+func TestWalkForPolicyFiles(t *testing.T) {
+	t.Parallel()
+	parser := NewParser()
+
+	root := t.TempDir()
+
+	// Valid policy file.
+	require.NoError(t, copyFile("testdata/policy.single.json", filepath.Join(root, "a.json")))
+	// Policy set with a remote ref.
+	require.NoError(t, copyFile("testdata/policy.remoteref.json", filepath.Join(root, "b.json")))
+	// Junk file that is not a policy.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "junk.json"), []byte(`{"x":1}`), 0o600))
+	// File with an unsupported extension is skipped even if content is a policy.
+	require.NoError(t, copyFile("testdata/policy.single.json", filepath.Join(root, "c.txt")))
+	// Hidden directory — its contents are skipped.
+	hidden := filepath.Join(root, ".hidden")
+	require.NoError(t, os.Mkdir(hidden, 0o750))
+	require.NoError(t, copyFile("testdata/policy.single.json", filepath.Join(hidden, "h.json")))
+
+	found, err := walkForPolicyFiles(root, parser)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		filepath.Join(root, "a.json"),
+		filepath.Join(root, "b.json"),
+	}, found)
+}
+
+func TestExtractAllRefs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	a := filepath.Join(root, "policy.remoteref.json")
+	b := filepath.Join(root, "group.remoteref.json")
+	c := filepath.Join(root, "policy.single.json") // no refs
+	require.NoError(t, copyFile("testdata/policy.remoteref.json", a))
+	require.NoError(t, copyFile("testdata/group.remoteref.json", b))
+	require.NoError(t, copyFile("testdata/policy.single.json", c))
+
+	u := NewUpdater()
+	refs := u.extractAllRefs([]string{a, b, c})
+
+	require.Len(t, refs, 2)
+
+	byFile := map[string]*extractedRef{}
+	for _, r := range refs {
+		byFile[r.file] = r
+	}
+
+	require.Contains(t, byFile, a)
+	require.Contains(t, byFile, b)
+
+	// PolicySet → Policy source ref.
+	aRef := byFile[a]
+	require.NotNil(t, aRef.components)
+	require.Equal(t, "github.com", aRef.components.Hostname)
+	require.Equal(t, "/carabiner-dev/policies", aRef.components.RepoPath)
+	require.Equal(t, "9a70ca49804c2b993bb6b62d51d5524f3443d6ec", aRef.components.Commit)
+	require.Equal(t, "sbom/sbom-exists.json", aRef.components.SubPath)
+
+	// PolicySet → PolicyGroup source ref (projected through groupRefToPolicyRef).
+	bRef := byFile[b]
+	require.NotNil(t, bRef.components)
+	require.Equal(t, "/carabiner-dev/examples", bRef.components.RepoPath)
+	require.Equal(t, "4c4ecf69b9c550fb2d57308f210a5de34802e8fb", bRef.components.Commit)
+}
+
+func TestCollectSourcesNoPolicies(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "junk.json"), []byte(`{"x":1}`), 0o600))
+
+	u := NewUpdater()
+	files, cleanup, err := u.collectSources([]string{dir})
+	defer cleanup()
+	require.NoError(t, err)
+	require.Empty(t, files)
+}
+
+func TestCollectSourcesFileAndDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.json")
+	require.NoError(t, copyFile("testdata/policy.single.json", a))
+
+	// A second directory containing one policy.
+	dir2 := t.TempDir()
+	b := filepath.Join(dir2, "b.json")
+	require.NoError(t, copyFile("testdata/policy.remoteref.json", b))
+
+	u := NewUpdater()
+	files, cleanup, err := u.collectSources([]string{a, dir2})
+	defer cleanup()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{a, b}, files)
+}
+
+func TestCollectSourcesUnknownLocation(t *testing.T) {
+	t.Parallel()
+	u := NewUpdater()
+	_, cleanup, err := u.collectSources([]string{"/definitely/does/not/exist"})
+	defer cleanup()
+	require.Error(t, err)
+}
+
+func TestCheckUpdatesNoLocations(t *testing.T) {
+	t.Parallel()
+	_, err := NewUpdater().CheckUpdates()
+	require.Error(t, err)
+}
+
+func TestCheckUpdatesNoPoliciesFound(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "junk.json"), []byte(`{"x":1}`), 0o600))
+	_, err := NewUpdater().CheckUpdates(dir)
+	require.Error(t, err)
+}
+
+func TestCheckUpdatesNoExternalRefs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	require.NoError(t, copyFile("testdata/policy.single.json", filepath.Join(dir, "p.json")))
+	// policy.single.json has no external refs, so no remote operations happen.
+	updates, err := NewUpdater().CheckUpdates(dir)
+	require.NoError(t, err)
+	require.Empty(t, updates)
+}
+
+// --- helpers ---
+
+type vcsTC struct {
+	Components vcslocator.Components
+}
+
+func vcsTestComponents(repo, sub string) *vcsTC {
+	return &vcsTC{
+		Components: vcslocator.Components{
+			Tool:      "git",
+			Transport: "https",
+			Hostname:  "github.com",
+			RepoPath:  repo,
+			SubPath:   sub,
+		},
+	}
+}
+
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0o600) //nolint:gosec // test helper; dst is always inside t.TempDir
+}


### PR DESCRIPTION
This pull request updates the direct and indirect dependencies in the `go.mod` file, specifically adjusting how `github.com/go-git/go-git/v5` and `github.com/nozzle/throttler` are referenced. The changes ensure these dependencies are now included as direct dependencies rather than indirect ones.

Dependency management updates:

* Promoted `github.com/go-git/go-git/v5` from an indirect to a direct dependency at version `v5.17.2`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R11-R14) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L49)
* Promoted `github.com/nozzle/throttler` from an indirect to a direct dependency at version `v0.0.0-20180817012639-2ea982251481`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R11-R14) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L93)