### PR TITLE
Add policy update methods

### DIFF
--- a/updater.go
+++ b/updater.go
@@ -283,7 +283,7 @@ func applyRefUpdates(file string, refs []*RefUpdate) ([]*RefUpdate, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, err := os.ReadFile(file) //nolint:gosec // path comes from the policy source set we just walked
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +325,7 @@ func applyRefUpdates(file string, refs []*RefUpdate) ([]*RefUpdate, error) {
 	if len(applied) == 0 {
 		return applied, nil
 	}
-	if err := os.WriteFile(file, []byte(out), info.Mode().Perm()); err != nil {
+	if err := os.WriteFile(file, []byte(out), info.Mode().Perm()); err != nil { //nolint:gosec // file is the policy source we just read; mode is preserved from its existing stat
 		return applied, err
 	}
 	return applied, nil

--- a/updater.go
+++ b/updater.go
@@ -224,6 +224,104 @@ func (u *Updater) CheckUpdates(locations ...string) (map[string][]*RefUpdate, er
 	return results, nil
 }
 
+// Update checks the given locations for available reference updates and
+// patches the matching policy source files in place. Only filesystem
+// locations (files or directories) are patched; VCS-locator locations
+// are skipped because their resolved files live in a temporary clone.
+// The returned map lists the updates that were actually applied, keyed
+// by source file path.
+func (u *Updater) Update(locations ...string) (map[string][]*RefUpdate, error) {
+	if len(locations) == 0 {
+		return nil, errors.New("no locations provided")
+	}
+
+	local := make([]string, 0, len(locations))
+	for _, loc := range locations {
+		if _, err := os.Stat(loc); err == nil {
+			local = append(local, loc)
+		}
+	}
+	if len(local) == 0 {
+		return nil, errors.New("no local locations to update (remote locations are not supported by Update)")
+	}
+
+	updates, err := u.CheckUpdates(local...)
+	if err != nil {
+		return nil, err
+	}
+
+	applied := map[string][]*RefUpdate{}
+	for file, refs := range updates {
+		patched, err := applyRefUpdates(file, refs)
+		if err != nil {
+			return applied, fmt.Errorf("patching %s: %w", file, err)
+		}
+		if len(patched) > 0 {
+			applied[file] = patched
+		}
+	}
+	return applied, nil
+}
+
+// applyRefUpdates rewrites file in place, replacing every old
+// URI/DownloadLocation/digest value with its new counterpart. The
+// replacements are done as raw string substitutions so that the file's
+// formatting, comments, and non-policy content are preserved verbatim.
+// Returns the list of updates whose values were actually present in the
+// file.
+func applyRefUpdates(file string, refs []*RefUpdate) ([]*RefUpdate, error) {
+	info, err := os.Stat(file)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(file) //nolint:gosec // path comes from the policy source set we just walked
+	if err != nil {
+		return nil, err
+	}
+
+	out := string(data)
+	applied := []*RefUpdate{}
+	for _, r := range refs {
+		mutated := false
+		oldLoc := r.Old.GetLocation()
+		newLoc := r.New.GetLocation()
+		if oldLoc == nil || newLoc == nil {
+			continue
+		}
+
+		if ov, nv := oldLoc.GetUri(), newLoc.GetUri(); ov != "" && ov != nv && strings.Contains(out, ov) {
+			out = strings.ReplaceAll(out, ov, nv)
+			mutated = true
+		}
+		if ov, nv := oldLoc.GetDownloadLocation(), newLoc.GetDownloadLocation(); ov != "" && ov != nv && strings.Contains(out, ov) {
+			out = strings.ReplaceAll(out, ov, nv)
+			mutated = true
+		}
+		for algo, ov := range oldLoc.GetDigest() {
+			nv, ok := newLoc.GetDigest()[algo]
+			if !ok || ov == "" || ov == nv {
+				continue
+			}
+			if !strings.Contains(out, ov) {
+				continue
+			}
+			out = strings.ReplaceAll(out, ov, nv)
+			mutated = true
+		}
+		if mutated {
+			applied = append(applied, r)
+		}
+	}
+
+	if len(applied) == 0 {
+		return applied, nil
+	}
+	if err := os.WriteFile(file, []byte(out), info.Mode().Perm()); err != nil {
+		return applied, err
+	}
+	return applied, nil
+}
+
 // extractedRef is the internal working copy of a reference under review.
 type extractedRef struct {
 	file       string

--- a/updater.go
+++ b/updater.go
@@ -249,7 +249,16 @@ func (u *Updater) Update(locations ...string) (map[string][]*RefUpdate, error) {
 	if err != nil {
 		return nil, err
 	}
+	return u.ApplyUpdates(updates)
+}
 
+// ApplyUpdates patches each file in the given updates map in place, using
+// the same backend as Update. This is the method to call when the updates
+// were computed elsewhere (e.g. loaded from a previously-saved plan) and
+// only the filesystem patch step needs to run. Returns the subset of
+// updates that were actually applied (i.e. whose old values were present
+// in their source file).
+func (u *Updater) ApplyUpdates(updates map[string][]*RefUpdate) (map[string][]*RefUpdate, error) {
 	applied := map[string][]*RefUpdate{}
 	for file, refs := range updates {
 		patched, err := applyRefUpdates(file, refs)

--- a/updater_test.go
+++ b/updater_test.go
@@ -6,6 +6,7 @@ package policy
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -477,11 +478,14 @@ func TestApplyRefUpdatesNoMatchLeavesFileUnchanged(t *testing.T) {
 
 func TestApplyRefUpdatesPreservesFileMode(t *testing.T) {
 	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permission bits do not round-trip through os.WriteFile/os.Stat on Windows")
+	}
 	dir := t.TempDir()
 	src := filepath.Join(dir, "policy.json")
 	const oldURI = "git+https://example.com/org/repo@deadbeef#p.json"
 	const newURI = "git+https://example.com/org/repo@cafef00d#p.json"
-	require.NoError(t, os.WriteFile(src, []byte(oldURI), 0o640))
+	require.NoError(t, os.WriteFile(src, []byte(oldURI), 0o640)) //nolint:gosec // intentional: test verifies applyRefUpdates preserves this exact mode
 
 	refs := []*RefUpdate{
 		{
@@ -514,7 +518,7 @@ func TestApplyRefUpdatesSkipsNilLocations(t *testing.T) {
 
 	got, err := os.ReadFile(src)
 	require.NoError(t, err)
-	require.Equal(t, body, string(got))
+	require.JSONEq(t, body, string(got))
 }
 
 func TestApplyRefUpdatesAppliesOnlyMatchingRefs(t *testing.T) {

--- a/updater_test.go
+++ b/updater_test.go
@@ -6,6 +6,7 @@ package policy
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/carabiner-dev/vcslocator"
@@ -390,6 +391,184 @@ func TestCheckUpdatesNoExternalRefs(t *testing.T) {
 	updates, err := NewUpdater().CheckUpdates(dir)
 	require.NoError(t, err)
 	require.Empty(t, updates)
+}
+
+func TestApplyRefUpdatesReplacesURIAndDigest(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "policy.json")
+	const oldURI = "git+https://example.com/org/repo@deadbeef#p.json"
+	const newURI = "git+https://example.com/org/repo@cafef00d#p.json"
+	const oldDigest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const newDigest = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	content := `{
+  "policies": [
+    {
+      "source": {
+        "location": {
+          "uri": "` + oldURI + `",
+          "digest": { "sha256": "` + oldDigest + `" }
+        }
+      }
+    }
+  ]
+}
+`
+	require.NoError(t, os.WriteFile(src, []byte(content), 0o600))
+
+	refs := []*RefUpdate{
+		{
+			Old: &api.PolicyRef{Location: &intoto.ResourceDescriptor{
+				Uri:    oldURI,
+				Digest: map[string]string{"sha256": oldDigest},
+			}},
+			New: &api.PolicyRef{Location: &intoto.ResourceDescriptor{
+				Uri:    newURI,
+				Digest: map[string]string{"sha256": newDigest},
+			}},
+		},
+	}
+
+	applied, err := applyRefUpdates(src, refs)
+	require.NoError(t, err)
+	require.Len(t, applied, 1)
+
+	patched, err := os.ReadFile(src)
+	require.NoError(t, err)
+	patchedStr := string(patched)
+	require.Contains(t, patchedStr, newURI)
+	require.Contains(t, patchedStr, newDigest)
+	require.NotContains(t, patchedStr, oldURI)
+	require.NotContains(t, patchedStr, oldDigest)
+
+	// Minimal-diff guarantee: only the two changed strings should differ
+	// from the original content.
+	expected := strings.ReplaceAll(content, oldURI, newURI)
+	expected = strings.ReplaceAll(expected, oldDigest, newDigest)
+	require.Equal(t, expected, patchedStr)
+}
+
+func TestApplyRefUpdatesNoMatchLeavesFileUnchanged(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "policy.json")
+	original := []byte(`{"id":"x"}`)
+	require.NoError(t, os.WriteFile(src, original, 0o600))
+
+	refs := []*RefUpdate{
+		{
+			Old: &api.PolicyRef{Location: &intoto.ResourceDescriptor{
+				Uri: "git+https://example.com/org/repo@deadbeef#p.json",
+			}},
+			New: &api.PolicyRef{Location: &intoto.ResourceDescriptor{
+				Uri: "git+https://example.com/org/repo@cafef00d#p.json",
+			}},
+		},
+	}
+
+	applied, err := applyRefUpdates(src, refs)
+	require.NoError(t, err)
+	require.Empty(t, applied)
+
+	got, err := os.ReadFile(src)
+	require.NoError(t, err)
+	require.Equal(t, original, got)
+}
+
+func TestApplyRefUpdatesPreservesFileMode(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "policy.json")
+	const oldURI = "git+https://example.com/org/repo@deadbeef#p.json"
+	const newURI = "git+https://example.com/org/repo@cafef00d#p.json"
+	require.NoError(t, os.WriteFile(src, []byte(oldURI), 0o640))
+
+	refs := []*RefUpdate{
+		{
+			Old: &api.PolicyRef{Location: &intoto.ResourceDescriptor{Uri: oldURI}},
+			New: &api.PolicyRef{Location: &intoto.ResourceDescriptor{Uri: newURI}},
+		},
+	}
+
+	_, err := applyRefUpdates(src, refs)
+	require.NoError(t, err)
+
+	info, err := os.Stat(src)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+}
+
+func TestApplyRefUpdatesSkipsNilLocations(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "policy.json")
+	const body = `{"id":"x"}`
+	require.NoError(t, os.WriteFile(src, []byte(body), 0o600))
+
+	refs := []*RefUpdate{
+		{Old: &api.PolicyRef{}, New: &api.PolicyRef{}},
+	}
+	applied, err := applyRefUpdates(src, refs)
+	require.NoError(t, err)
+	require.Empty(t, applied)
+
+	got, err := os.ReadFile(src)
+	require.NoError(t, err)
+	require.Equal(t, body, string(got))
+}
+
+func TestApplyRefUpdatesAppliesOnlyMatchingRefs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "policy.json")
+	const presentOld = "git+https://example.com/a/b@1111111#p.json"
+	const presentNew = "git+https://example.com/a/b@2222222#p.json"
+	const absentOld = "git+https://example.com/c/d@3333333#q.json"
+	const absentNew = "git+https://example.com/c/d@4444444#q.json"
+	require.NoError(t, os.WriteFile(src, []byte(presentOld), 0o600))
+
+	refs := []*RefUpdate{
+		{
+			Old: &api.PolicyRef{Location: &intoto.ResourceDescriptor{Uri: presentOld}},
+			New: &api.PolicyRef{Location: &intoto.ResourceDescriptor{Uri: presentNew}},
+		},
+		{
+			Old: &api.PolicyRef{Location: &intoto.ResourceDescriptor{Uri: absentOld}},
+			New: &api.PolicyRef{Location: &intoto.ResourceDescriptor{Uri: absentNew}},
+		},
+	}
+
+	applied, err := applyRefUpdates(src, refs)
+	require.NoError(t, err)
+	require.Len(t, applied, 1)
+	require.Equal(t, presentOld, applied[0].Old.GetLocation().GetUri())
+
+	got, err := os.ReadFile(src)
+	require.NoError(t, err)
+	require.Equal(t, presentNew, string(got))
+}
+
+func TestUpdateNoLocations(t *testing.T) {
+	t.Parallel()
+	_, err := NewUpdater().Update()
+	require.Error(t, err)
+}
+
+func TestUpdateNoLocalLocations(t *testing.T) {
+	t.Parallel()
+	_, err := NewUpdater().Update("/definitely/does/not/exist")
+	require.Error(t, err)
+}
+
+func TestUpdateLocalNoExternalRefs(t *testing.T) {
+	t.Parallel()
+	// A policy with no external refs means CheckUpdates returns empty
+	// and Update has nothing to patch — no network calls are made.
+	dir := t.TempDir()
+	require.NoError(t, copyFile("testdata/policy.single.json", filepath.Join(dir, "p.json")))
+	applied, err := NewUpdater().Update(dir)
+	require.NoError(t, err)
+	require.Empty(t, applied)
 }
 
 // --- helpers ---


### PR DESCRIPTION
This pull request adds support for in-place patching of policy source files to update reference URIs and digests, along with comprehensive tests for the new functionality. The main changes introduce new methods to the `Updater` for applying updates, ensuring only local files are modified, and verifying that file contents and permissions are handled correctly.

**New update and patching functionality:**

* Added `Updater.Update` and `Updater.ApplyUpdates` methods to check for reference updates and patch local policy source files in place, skipping remote/VCS sources.
* Implemented `applyRefUpdates` helper to perform minimal-diff, in-place string substitutions for URIs and digests in policy files, preserving formatting and file mode.

**Testing enhancements:**

* Added tests for `applyRefUpdates` covering URI/digest replacement, no-op when no matches, file mode preservation, nil location handling, and partial application when only some refs match.
* Added tests for `Updater.Update` error handling (no locations, no local locations) and correct behavior when no external refs are present.

**Dependency update:**

* Imported `strings` in `updater_test.go` for string replacement in test assertions.