### PR TITLE
Expressions in context values

### DIFF
--- a/api/v1/context.go
+++ b/api/v1/context.go
@@ -25,6 +25,15 @@ func (cv *ContextVal) Validate() error {
 	if cv.GetType() != "" && !slices.Contains(ContextTypes, cv.GetType()) {
 		return fmt.Errorf("invalid context type: %q", cv.GetType())
 	}
+	if cv.Value != nil && cv.Expression != nil {
+		return fmt.Errorf("context value cannot define both `value` and `expression`")
+	}
+	if cv.Default != nil && cv.Expression != nil {
+		return fmt.Errorf("context value cannot define both `default` and `expression`")
+	}
+	if cv.Expression == nil && cv.GetRuntime() != "" {
+		return fmt.Errorf("context value `runtime` is only valid when `expression` is set")
+	}
 	return nil
 }
 
@@ -39,5 +48,11 @@ func (cv *ContextVal) Merge(cv2 *ContextVal) {
 	}
 	if v := cv2.Required; v != nil {
 		cv.Required = v
+	}
+	if v := cv2.Expression; v != nil {
+		cv.Expression = v
+	}
+	if v := cv2.Runtime; v != nil {
+		cv.Runtime = v
 	}
 }

--- a/api/v1/context_test.go
+++ b/api/v1/context_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestContextValValidate(t *testing.T) {
@@ -21,6 +22,17 @@ func TestContextValValidate(t *testing.T) {
 		{"no-value", &ContextVal{Type: "int"}, false},
 		{"no-value", &ContextVal{Type: "bool"}, false},
 		{"no-value", &ContextVal{Type: "something-else"}, true},
+		{"expression-only", &ContextVal{Expression: ptrString("subject.name")}, false},
+		{"expression-and-runtime", &ContextVal{Expression: ptrString("subject.name"), Runtime: ptrString("cel@v0")}, false},
+		{"runtime-without-expression", &ContextVal{Runtime: ptrString("cel@v0")}, true},
+		{"value-and-expression", &ContextVal{
+			Value:      structpb.NewStringValue("x"),
+			Expression: ptrString("subject.name"),
+		}, true},
+		{"default-and-expression", &ContextVal{
+			Default:    structpb.NewStringValue("x"),
+			Expression: ptrString("subject.name"),
+		}, true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -33,3 +45,5 @@ func TestContextValValidate(t *testing.T) {
 		})
 	}
 }
+
+func ptrString(s string) *string { return &s }

--- a/api/v1/policy.pb.go
+++ b/api/v1/policy.pb.go
@@ -880,7 +880,15 @@ type ContextVal struct {
 	// default value should be castable into the type defined in type
 	Default *structpb.Value `protobuf:"bytes,4,opt,name=default,proto3,oneof" json:"default,omitempty"`
 	// Human readable description of the ContextValue
-	Description   *string `protobuf:"bytes,5,opt,name=description,proto3,oneof" json:"description,omitempty"`
+	Description *string `protobuf:"bytes,5,opt,name=description,proto3,oneof" json:"description,omitempty"`
+	// Expression is an evaluator-language snippet resolved at evaluation time
+	// to produce the context value dynamically (e.g. from the subject under
+	// evaluation). It is mutually exclusive with both `value` and `default`,
+	// since an expression is a burned-in computation with no static fallback.
+	Expression *string `protobuf:"bytes,6,opt,name=expression,proto3,oneof" json:"expression,omitempty"`
+	// Runtime selects the evaluator used to resolve `expression`. When empty,
+	// the policy's default runtime is used.
+	Runtime       *string `protobuf:"bytes,7,opt,name=runtime,proto3,oneof" json:"runtime,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -946,6 +954,20 @@ func (x *ContextVal) GetDefault() *structpb.Value {
 func (x *ContextVal) GetDescription() string {
 	if x != nil && x.Description != nil {
 		return *x.Description
+	}
+	return ""
+}
+
+func (x *ContextVal) GetExpression() string {
+	if x != nil && x.Expression != nil {
+		return *x.Expression
+	}
+	return ""
+}
+
+func (x *ContextVal) GetRuntime() string {
+	if x != nil && x.Runtime != nil {
+		return *x.Runtime
 	}
 	return ""
 }
@@ -1959,19 +1981,26 @@ const file_carabiner_policy_v1_policy_proto_rawDesc = "" +
 	"\x05title\x18\x02 \x01(\tR\x05title\x12\x1c\n" +
 	"\tframework\x18\x03 \x01(\tR\tframework\x12\x14\n" +
 	"\x05class\x18\x04 \x01(\tR\x05class\x12\x12\n" +
-	"\x04item\x18\x05 \x01(\tR\x04item\"\x85\x02\n" +
+	"\x04item\x18\x05 \x01(\tR\x04item\"\xe4\x02\n" +
 	"\n" +
 	"ContextVal\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x1f\n" +
 	"\brequired\x18\x02 \x01(\bH\x00R\brequired\x88\x01\x01\x121\n" +
 	"\x05value\x18\x03 \x01(\v2\x16.google.protobuf.ValueH\x01R\x05value\x88\x01\x01\x125\n" +
 	"\adefault\x18\x04 \x01(\v2\x16.google.protobuf.ValueH\x02R\adefault\x88\x01\x01\x12%\n" +
-	"\vdescription\x18\x05 \x01(\tH\x03R\vdescription\x88\x01\x01B\v\n" +
+	"\vdescription\x18\x05 \x01(\tH\x03R\vdescription\x88\x01\x01\x12#\n" +
+	"\n" +
+	"expression\x18\x06 \x01(\tH\x04R\n" +
+	"expression\x88\x01\x01\x12\x1d\n" +
+	"\aruntime\x18\a \x01(\tH\x05R\aruntime\x88\x01\x01B\v\n" +
 	"\t_requiredB\b\n" +
 	"\x06_valueB\n" +
 	"\n" +
 	"\b_defaultB\x0e\n" +
-	"\f_description\"=\n" +
+	"\f_descriptionB\r\n" +
+	"\v_expressionB\n" +
+	"\n" +
+	"\b_runtime\"=\n" +
 	"\x05Error\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12\x1a\n" +
 	"\bguidance\x18\x02 \x01(\tR\bguidance\"\x93\x01\n" +

--- a/proto/carabiner/policy/v1/policy.proto
+++ b/proto/carabiner/policy/v1/policy.proto
@@ -160,19 +160,33 @@ message Control {
 
 // ContextVal defines a contextual value needed by a policy. Context values
 // are defined from external sources at runtime and if required will cause the
-// policy to fail if unset. 
+// policy to fail if unset.
 message ContextVal {
     // Data type of the context value. Enforced values are "string", "int", "bool", "float".
     string type = 1;
+
     // Required flag. If set to true, policies will not evaluate if the context value is not set.
     optional bool required = 2;
+
     // Value field. If the ContextVal is typed, the data should be castable to the type defined in Type.
     optional google.protobuf.Value value = 3;
+
     // Default value when ContextVal is not set. If the ContextVal is typed, the
     // default value should be castable into the type defined in type
     optional google.protobuf.Value default = 4;
+
     // Human readable description of the ContextValue
     optional string description = 5;
+
+    // Expression is an evaluator-language snippet resolved at evaluation time
+    // to produce the context value dynamically (e.g. from the subject under
+    // evaluation). It is mutually exclusive with both `value` and `default`,
+    // since an expression is a burned-in computation with no static fallback.
+    optional string expression = 6;
+
+    // Runtime selects the evaluator used to resolve `expression`. When empty,
+    // the policy's default runtime is used.
+    optional string runtime = 7;
 }
 
 // The error structure is returned when a policy is evaluated successfully but 


### PR DESCRIPTION
This PR updates the policy definition protos to support expressions in context values. In addition to static values, context can now come from an expression. 

Context expressions are mutually exclusive with baked-in values (and default values). The Validate() method has been updated to check consistency. Tests are also updated.