### PR TITLE
Fix minor bugs

### DIFF
--- a/api/v1/context.go
+++ b/api/v1/context.go
@@ -38,8 +38,22 @@ func (cv *ContextVal) Validate() error {
 }
 
 // Merge merges the values set in cv2 into cv. If values are not set nothing
-// is replaced
+// is replaced.
+//
+// Static (value/default) and dynamic (expression/runtime) forms are mutually
+// exclusive, so when cv2 introduces one form, any stale fields of the other
+// form on cv are cleared before applying cv2's values. This keeps a merged
+// ContextVal within the shape Validate() accepts.
 func (cv *ContextVal) Merge(cv2 *ContextVal) {
+	switch {
+	case cv2.Expression != nil:
+		cv.Value = nil
+		cv.Default = nil
+	case cv2.Value != nil || cv2.Default != nil:
+		cv.Expression = nil
+		cv.Runtime = nil
+	}
+
 	if v := cv2.Default; v != nil {
 		cv.Default = v
 	}

--- a/api/v1/context_test.go
+++ b/api/v1/context_test.go
@@ -47,3 +47,64 @@ func TestContextValValidate(t *testing.T) {
 }
 
 func ptrString(s string) *string { return &s }
+
+func TestContextValMerge(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name  string
+		base  *ContextVal
+		patch *ContextVal
+		want  *ContextVal
+	}{
+		{
+			"expression-clears-static",
+			&ContextVal{Value: structpb.NewStringValue("x"), Default: structpb.NewStringValue("y")},
+			&ContextVal{Expression: ptrString("subject.name")},
+			&ContextVal{Expression: ptrString("subject.name")},
+		},
+		{
+			"value-clears-expression",
+			&ContextVal{Expression: ptrString("subject.name"), Runtime: ptrString("cel@v0")},
+			&ContextVal{Value: structpb.NewStringValue("x")},
+			&ContextVal{Value: structpb.NewStringValue("x")},
+		},
+		{
+			"default-clears-expression",
+			&ContextVal{Expression: ptrString("subject.name"), Runtime: ptrString("cel@v0")},
+			&ContextVal{Default: structpb.NewStringValue("x")},
+			&ContextVal{Default: structpb.NewStringValue("x")},
+		},
+		{
+			"required-does-not-clear-either-form",
+			&ContextVal{Expression: ptrString("subject.name")},
+			&ContextVal{Required: func() *bool { b := true; return &b }()},
+			&ContextVal{Expression: ptrString("subject.name"), Required: func() *bool { b := true; return &b }()},
+		},
+		{
+			"runtime-only-patch-preserves-expression",
+			&ContextVal{Expression: ptrString("subject.name")},
+			&ContextVal{Runtime: ptrString("cel@v0")},
+			&ContextVal{Expression: ptrString("subject.name"), Runtime: ptrString("cel@v0")},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.base.Merge(tt.patch)
+			require.NoError(t, tt.base.Validate(), "merged ContextVal must pass Validate()")
+			require.Equal(t, tt.want.GetExpression(), tt.base.GetExpression())
+			require.Equal(t, tt.want.GetRuntime(), tt.base.GetRuntime())
+			if tt.want.Value == nil {
+				require.Nil(t, tt.base.Value)
+			} else {
+				require.NotNil(t, tt.base.Value)
+				require.Equal(t, tt.want.Value.AsInterface(), tt.base.Value.AsInterface())
+			}
+			if tt.want.Default == nil {
+				require.Nil(t, tt.base.Default)
+			} else {
+				require.NotNil(t, tt.base.Default)
+				require.Equal(t, tt.want.Default.AsInterface(), tt.base.Default.AsInterface())
+			}
+		})
+	}
+}

--- a/api/v1/policy.go
+++ b/api/v1/policy.go
@@ -162,10 +162,15 @@ func (p *Policy) SetOrigin(origin attestation.Subject) {
 // interface te be able to be wrapped in an intoto statement
 
 // ContextMap compiles the context data values into a map, filling the fields
-// with their defaults when needed.
+// with their defaults when needed. Entries whose value is resolved dynamically
+// via an `expression` are skipped: they cannot be known without an evaluator
+// and an evaluation context.
 func (p *Policy) ContextMap() map[string]any {
 	ret := map[string]any{}
 	for label, value := range p.Context {
+		if value.GetExpression() != "" {
+			continue
+		}
 		if value.Value != nil {
 			ret[label] = value.Value.AsInterface()
 		} else {

--- a/api/v1/policygroup.go
+++ b/api/v1/policygroup.go
@@ -4,6 +4,7 @@
 package v1
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/carabiner-dev/attestation"
@@ -31,7 +32,20 @@ func (ref *PolicyGroupRef) SetVersion(v int64) {
 
 // Validate checks the consistency of the policy group
 func (grp *PolicyGroup) Validate() error {
-	return nil
+	errs := []error{}
+	for key, def := range grp.GetCommon().GetContext() {
+		if err := def.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("invalid common context definition for %q: %w", key, err))
+		}
+	}
+	for _, b := range grp.GetBlocks() {
+		for _, p := range b.GetPolicies() {
+			if err := p.Validate(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // PublicKeys returns any public keys defined in the policy identities

--- a/api/v1/policyset.go
+++ b/api/v1/policyset.go
@@ -81,10 +81,15 @@ func (set *PolicySet) GetData() []byte {
 }
 
 // ContextMap compiles the context data values into a map, filling the fields
-// with their defaults when needed.
+// with their defaults when needed. Entries whose value is resolved dynamically
+// via an `expression` are skipped: they cannot be known without an evaluator
+// and an evaluation context.
 func (s *PolicySet) ContextMap() map[string]any {
 	ret := map[string]any{}
 	for label, value := range s.GetCommon().GetContext() {
+		if value.GetExpression() != "" {
+			continue
+		}
 		if value.Value != nil {
 			ret[label] = value.Value.AsInterface()
 		} else {

--- a/api/v1/policyset.go
+++ b/api/v1/policyset.go
@@ -26,8 +26,18 @@ func (set *PolicySet) Validate() error {
 
 	// TODO: Check all IDS are unique (including policy set, policies and groups)
 	errs := []error{}
+	for key, def := range set.GetCommon().GetContext() {
+		if err := def.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("invalid common context definition for %q: %w", key, err))
+		}
+	}
 	for _, p := range set.GetPolicies() {
 		if err := p.Validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	for _, g := range set.GetGroups() {
+		if err := g.Validate(); err != nil {
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
This pull request improves the validation and merging logic for context values in policy-related data structures, and enhances how context maps are constructed to handle dynamic expressions correctly. It also adds comprehensive tests for the new merge behavior and strengthens validation in policy sets and groups.

**Validation and merging improvements:**

* Updated `ContextVal.Merge` to ensure static (value/default) and dynamic (expression/runtime) forms are mutually exclusive—merging one form clears the other, preventing invalid mixed states.
* Added a thorough test suite for `ContextVal.Merge` covering various edge cases to verify correct field clearing and preservation.

**Context map construction:**

* Modified `Policy.ContextMap` and `PolicySet.ContextMap` to skip context entries with dynamic `expression` fields, since their values can't be determined statically. [[1]](diffhunk://#diff-ef00264377fc13d8c98553ecf7f2b49aac364746f8dfb8e3fb22ade8b697d6b4L165-R173) [[2]](diffhunk://#diff-ff8a20349328c895be611e6377c5d11bfefb69f7dd7a30a687340bd4b2d47ed5L74-R92)

**Validation enhancements:**

* Improved `PolicyGroup.Validate` and `PolicySet.Validate` to recursively validate all context definitions, policies, and groups, aggregating errors for better diagnostics. [[1]](diffhunk://#diff-5cd63dd819d6f3bf0481b4ba268efa595c7c39849ea4008810dc272ce8909de6L34-R48) [[2]](diffhunk://#diff-ff8a20349328c895be611e6377c5d11bfefb69f7dd7a30a687340bd4b2d47ed5R29-R43)

**Other:**

* Added missing import of the `errors` package in `policygroup.go` to support error aggregation.