### PR TITLE
fix: inherit assert_mode when assembling remote PolicyGroup

### DIFF
--- a/compiler_implementation.go
+++ b/compiler_implementation.go
@@ -496,6 +496,9 @@ func (dci *defaultCompilerImpl) assemblePolicyGroup(opts *CompilerOptions, grp *
 		if assembledGroup.GetMeta().GetEnforce() == "" {
 			assembledGroup.GetMeta().Enforce = remotePolicyGroup.GetMeta().GetEnforce()
 		}
+		if assembledGroup.GetMeta().GetAssertMode() == "" {
+			assembledGroup.GetMeta().AssertMode = remotePolicyGroup.GetMeta().GetAssertMode()
+		}
 		// optional google.protobuf.Timestamp expiration = 5; <<< Expiration is not inherited
 		// optional in_toto_attestation.v1.ResourceDescriptor origin = 6; <<< From pulled data
 


### PR DESCRIPTION
assemblePolicyGroup merged description, controls, and enforce from the remote group meta but skipped assert_mode. A group HJSON with assert_mode:OR would silently default to AND when loaded through a PolicySet, causing groups to fail even when a passing block existed.

Fix #147 